### PR TITLE
Add figma.(jsx|js) resolve extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,9 @@ const baseConfig = {
     },
 
     // Webpack tries these extensions for you if you omit the extension like "import './file'"
-    resolve: { extensions: ['.figma.tsx', '.figma.ts','.tsx', '.ts', '.jsx', '.js'] },
+    resolve: {
+      extensions: ['.figma.tsx', '.figma.ts', 'figma.jsx', '.figma.js', '.tsx', '.ts', '.jsx', '.js']
+    },
 
     output: {
         filename: '[name].js',


### PR DESCRIPTION
Resolves #1 so that dependencies with imports of `index.figma.js` resolve before `index.js`